### PR TITLE
fix useAuth decorator link to authentication section

### DIFF
--- a/docs/standard-library/http/reference/decorators.md
+++ b/docs/standard-library/http/reference/decorators.md
@@ -402,7 +402,7 @@ op create(): {@statusCode: 201 | 202}
 
 ### `@useAuth` {#@TypeSpec.Http.useAuth}
 
-Specify this service authentication. See the [documentation in the Http library][https://microsoft.github.io/typespec/standard-library/rest/authentication] for full details.
+Specify this service authentication. See the [documentation in the Http library](https://microsoft.github.io/typespec/standard-library/http/authentication) for full details.
 
 ```typespec
 @TypeSpec.Http.useAuth(auth: {} | Union | {}[])


### PR DESCRIPTION
Authentication has moved to http but the link is pointing to /rest which results in a not found page. Also it was not linked correctly